### PR TITLE
feat: Review 관련 CRUD 작성

### DIFF
--- a/src/main/java/com/example/movielog/controller/review/ReviewRequest.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewRequest.java
@@ -1,0 +1,22 @@
+package com.example.movielog.controller.review;
+
+import com.example.movielog.model.movie.Movie;
+import com.example.movielog.model.review.Review;
+import com.example.movielog.model.user.User;
+
+public class ReviewRequest {
+
+  private String title;
+
+  private String content;
+
+  public String getTitle() { return title; }
+
+  public String getContent(){ return content; }
+
+  protected ReviewRequest() {}
+
+  public Review newReview(User user, Movie movie, String title, String content){
+    return new Review(movie, user, title, content);
+  }
+}

--- a/src/main/java/com/example/movielog/controller/review/ReviewResponse.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewResponse.java
@@ -1,0 +1,26 @@
+package com.example.movielog.controller.review;
+
+import com.example.movielog.model.review.Review;
+import lombok.Getter;
+
+@Getter
+public class ReviewResponse {
+
+  private Long id;
+
+  private String title;
+
+  private String content;
+
+  private String nickname;
+
+  private String movietitle;
+
+  public ReviewResponse(Review review) {
+    id = review.getId();
+    title = review.getTitle();
+    content = review.getContent();
+    nickname = review.getUser().getNickname();
+    movietitle = review.getMovie().getTitle();
+  }
+}

--- a/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
@@ -12,9 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RequestMapping("/review")
@@ -28,26 +28,20 @@ public class ReviewRestController {
   private final MovieService movieService;
 
   @PostMapping("/write/{movieId}")
-  public ResponseEntity<Review> write(@AuthenticationPrincipal UserAccount userAccount,
+  public Long write(@AuthenticationPrincipal UserAccount userAccount,
                                       @RequestBody ReviewRequest reviewRequest,
                                       @PathVariable("movieId") Long movieId){
+
     User user = userService.findByEmail(userAccount.getUsername())
           .orElseThrow(()-> new UsernameNotFoundException("존재하지 않는 회원입니다."));
 
     Movie movie = movieService.findById(movieId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화입니다."));
 
-    reviewService.write(reviewRequest
-            .newReview(user, movie, reviewRequest.getTitle(), reviewRequest.getContent()));
-
-//    Review savedReview = reviewService.get;
-//
-//    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
-//            .path("/{movieId}")
-//            .buildAndExpand(saveReview.getId())
-//            .toUri();
-//
-//    return ResponseEntity.created(location).build();
-    return null;
+    return reviewService.write(reviewRequest
+            .newReview(user, movie, reviewRequest.getTitle(), reviewRequest.getContent()))
+            .getId();
   }
+
+
 }

--- a/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
@@ -1,0 +1,53 @@
+package com.example.movielog.controller.review;
+
+import com.example.movielog.model.movie.Movie;
+import com.example.movielog.model.review.Review;
+import com.example.movielog.model.user.User;
+import com.example.movielog.model.user.UserAccount;
+import com.example.movielog.service.MovieService;
+import com.example.movielog.service.ReviewService;
+import com.example.movielog.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RequiredArgsConstructor
+@RequestMapping("/review")
+@RestController
+public class ReviewRestController {
+
+  private final ReviewService reviewService;
+
+  private final UserService userService;
+
+  private final MovieService movieService;
+
+  @PostMapping("/write/{movieId}")
+  public ResponseEntity<Review> write(@AuthenticationPrincipal UserAccount userAccount,
+                                      @RequestBody ReviewRequest reviewRequest,
+                                      @PathVariable("movieId") Long movieId){
+    User user = userService.findByEmail(userAccount.getUsername())
+          .orElseThrow(()-> new UsernameNotFoundException("존재하지 않는 회원입니다."));
+
+    Movie movie = movieService.findById(movieId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화입니다."));
+
+    reviewService.write(reviewRequest
+            .newReview(user, movie, reviewRequest.getTitle(), reviewRequest.getContent()));
+
+//    Review savedReview = reviewService.get;
+//
+//    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+//            .path("/{movieId}")
+//            .buildAndExpand(saveReview.getId())
+//            .toUri();
+//
+//    return ResponseEntity.created(location).build();
+    return null;
+  }
+}

--- a/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
@@ -72,4 +72,18 @@ public class ReviewRestController {
 
     reviewService.delete(review);
   }
+
+  @GetMapping("/my")
+  public ResponseEntity<List<ReviewResponse>> myReviews(@AuthenticationPrincipal UserAccount userAccount){
+    User user = userService.findByEmail(userAccount.getUsername())
+            .orElseThrow(()-> new UsernameNotFoundException("존재하지 않는 회원입니다."));
+
+    List<Review> reviewList = reviewService.findAllByUser(user);
+
+    List<ReviewResponse> collect = reviewList.stream()
+            .map(ReviewResponse::new)
+            .collect(Collectors.toList());
+
+    return ResponseEntity.ok(collect);
+  }
 }

--- a/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
@@ -43,5 +43,14 @@ public class ReviewRestController {
             .getId();
   }
 
+  @GetMapping("")
+  public ResponseEntity<List<ReviewResponse>> reviews() {
+    List<Review> reviewList = reviewService.findAll();
 
+    List<ReviewResponse> collect = reviewList.stream()
+            .map(ReviewResponse::new)
+            .collect(Collectors.toList());
+
+    return ResponseEntity.ok(collect);
+  }
 }

--- a/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
@@ -64,4 +64,12 @@ public class ReviewRestController {
 
     return reviewId;
   }
+
+  @DeleteMapping("/{reviewId}")
+  public void delete(@PathVariable("reviewId") Long reviewId){
+    Review review = reviewService.findById(reviewId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다"));
+
+    reviewService.delete(review);
+  }
 }

--- a/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewRestController.java
@@ -53,4 +53,15 @@ public class ReviewRestController {
 
     return ResponseEntity.ok(collect);
   }
+
+  @PostMapping("/update/{reviewId}")
+  public Long update(@RequestBody ReviewUpdateRequest reviewUpdateRequest,
+                     @PathVariable("reviewId") Long reviewId){
+    Review review = reviewService.findById(reviewId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다"));
+
+    reviewService.update(review, reviewUpdateRequest.getTitle(), reviewUpdateRequest.getContent());
+
+    return reviewId;
+  }
 }

--- a/src/main/java/com/example/movielog/controller/review/ReviewUpdateRequest.java
+++ b/src/main/java/com/example/movielog/controller/review/ReviewUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.example.movielog.controller.review;
+
+public class ReviewUpdateRequest {
+  private String title;
+  private String content;
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  protected ReviewUpdateRequest() {}
+
+  public ReviewUpdateRequest(String title, String content) {
+    this.title = title;
+    this.content = content;
+  }
+}

--- a/src/main/java/com/example/movielog/model/movie/Movie.java
+++ b/src/main/java/com/example/movielog/model/movie/Movie.java
@@ -1,17 +1,19 @@
 package com.example.movielog.model.movie;
 
+import com.example.movielog.model.review.Review;
 import lombok.Builder;
 import lombok.Getter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 public class Movie {
 
   @Id @GeneratedValue
+  @Column(name = "MOVIE_NO")
   private Long no;
 
   private String title;
@@ -22,6 +24,9 @@ public class Movie {
   private int price;
   private String image;
   private double user_rating;
+
+  @OneToMany(mappedBy = "movie")
+  private List<Review> reviews = new ArrayList<>();
 
   public Movie(){}
 

--- a/src/main/java/com/example/movielog/model/review/Review.java
+++ b/src/main/java/com/example/movielog/model/review/Review.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @Entity
 public class Review {
 
-  @Id @GeneratedValue
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "REVIEW_NO")
   private Long id;
 

--- a/src/main/java/com/example/movielog/model/review/Review.java
+++ b/src/main/java/com/example/movielog/model/review/Review.java
@@ -10,7 +10,6 @@ import javax.persistence.*;
 
 @Getter
 @Entity
-@Builder
 public class Review {
 
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,11 +37,8 @@ public class Review {
     this.content = content;
   }
 
-  public Review(Long id, String title, String content, User user, Movie movie){
-    this.id = id;
+  public void update(String title, String content){
     this.title = title;
     this.content = content;
-    this.user = user;
-    this.movie = movie;
   }
 }

--- a/src/main/java/com/example/movielog/model/review/Review.java
+++ b/src/main/java/com/example/movielog/model/review/Review.java
@@ -2,12 +2,15 @@ package com.example.movielog.model.review;
 
 import com.example.movielog.model.movie.Movie;
 import com.example.movielog.model.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.persistence.*;
 
 @Getter
 @Entity
+@Builder
 public class Review {
 
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/movielog/model/review/Review.java
+++ b/src/main/java/com/example/movielog/model/review/Review.java
@@ -1,0 +1,45 @@
+package com.example.movielog.model.review;
+
+import com.example.movielog.model.movie.Movie;
+import com.example.movielog.model.user.User;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+public class Review {
+
+  @Id @GeneratedValue
+  @Column(name = "REVIEW_NO")
+  private Long id;
+
+  private String title;
+
+  private String content;
+
+  @JoinColumn(name = "USER_NO")
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User user;
+
+  @JoinColumn(name = "MOVIE_NO")
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Movie movie;
+
+  public Review(){}
+
+  public Review(Movie movie, User user, String title, String content) {
+    this.movie = movie;
+    this.user = user;
+    this.title = title;
+    this.content = content;
+  }
+
+  public Review(Long id, String title, String content, User user, Movie movie){
+    this.id = id;
+    this.title = title;
+    this.content = content;
+    this.user = user;
+    this.movie = movie;
+  }
+}

--- a/src/main/java/com/example/movielog/model/user/User.java
+++ b/src/main/java/com/example/movielog/model/user/User.java
@@ -1,5 +1,6 @@
 package com.example.movielog.model.user;
 
+import com.example.movielog.model.review.Review;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 public class User implements UserDetails {
 
   @Id @GeneratedValue
+  @Column(name = "USER_NO")
   private Long id;
 
   private String email;
@@ -29,6 +31,9 @@ public class User implements UserDetails {
   private String password;
 
   private String nickname;
+
+  @OneToMany(mappedBy = "user")
+  private List<Review> reviews = new ArrayList<>();
 
   public User(String email, String password, String nickname){
     this.email = email;

--- a/src/main/java/com/example/movielog/repository/review/ReviewRepository.java
+++ b/src/main/java/com/example/movielog/repository/review/ReviewRepository.java
@@ -1,7 +1,11 @@
 package com.example.movielog.repository.review;
 
 import com.example.movielog.model.review.Review;
+import com.example.movielog.model.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+  List<Review> findAllByUser(User user);
 }

--- a/src/main/java/com/example/movielog/repository/review/ReviewRepository.java
+++ b/src/main/java/com/example/movielog/repository/review/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.example.movielog.repository.review;
+
+import com.example.movielog.model.review.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/example/movielog/service/ReviewService.java
+++ b/src/main/java/com/example/movielog/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.example.movielog.service;
 import com.example.movielog.controller.review.ReviewRequest;
 import com.example.movielog.controller.review.ReviewResponse;
 import com.example.movielog.model.review.Review;
+import com.example.movielog.model.user.User;
 import com.example.movielog.repository.review.ReviewRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -44,5 +45,10 @@ public class ReviewService {
   @Transactional
   public void delete(Review review){
     reviewRepository.delete(review);
+  }
+
+  @Transactional
+  public List<Review> findAllByUser(User user){
+    return reviewRepository.findAllByUser(user);
   }
 }

--- a/src/main/java/com/example/movielog/service/ReviewService.java
+++ b/src/main/java/com/example/movielog/service/ReviewService.java
@@ -1,9 +1,15 @@
 package com.example.movielog.service;
 
+import com.example.movielog.controller.review.ReviewRequest;
+import com.example.movielog.controller.review.ReviewResponse;
 import com.example.movielog.model.review.Review;
 import com.example.movielog.repository.review.ReviewRepository;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ReviewService {
@@ -17,5 +23,15 @@ public class ReviewService {
   @Transactional
   public Review write(Review review){
     return reviewRepository.save(review);
+  }
+
+  @Transactional
+  public Optional<Review> findById(Long id){
+    return reviewRepository.findById(id);
+  }
+
+  @Transactional
+  public List<Review> findAll(){
+    return reviewRepository.findAll();
   }
 }

--- a/src/main/java/com/example/movielog/service/ReviewService.java
+++ b/src/main/java/com/example/movielog/service/ReviewService.java
@@ -1,0 +1,21 @@
+package com.example.movielog.service;
+
+import com.example.movielog.model.review.Review;
+import com.example.movielog.repository.review.ReviewRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ReviewService {
+
+  private final ReviewRepository reviewRepository;
+
+  public ReviewService(ReviewRepository reviewRepository){
+    this.reviewRepository = reviewRepository;
+  }
+
+  @Transactional
+  public Review write(Review review){
+    return reviewRepository.save(review);
+  }
+}

--- a/src/main/java/com/example/movielog/service/ReviewService.java
+++ b/src/main/java/com/example/movielog/service/ReviewService.java
@@ -34,4 +34,10 @@ public class ReviewService {
   public List<Review> findAll(){
     return reviewRepository.findAll();
   }
+
+  @Transactional
+  public Long update(Review review, String title, String content){
+    review.update(title, content);
+    return reviewRepository.save(review).getId();
+  }
 }

--- a/src/main/java/com/example/movielog/service/ReviewService.java
+++ b/src/main/java/com/example/movielog/service/ReviewService.java
@@ -40,4 +40,9 @@ public class ReviewService {
     review.update(title, content);
     return reviewRepository.save(review).getId();
   }
+
+  @Transactional
+  public void delete(Review review){
+    reviewRepository.delete(review);
+  }
 }


### PR DESCRIPTION
closes #7 #8 #9 #10 #11

## 구현한 것
- 리뷰 작성
- 리뷰 조회
  - 전체 리뷰 조회
  - 로그인 한 유저가 작성한 리뷰 조회
- 리뷰 수정
- 리뷰 삭제


## 고민했던 점
- #7 : Create를 할 때 client에서 요청받은 것이 정상 처리되었을 때 client에 어떤 정보를 넘겨줘야 좋은 코드가 될지 고민이 되었음. 

- #8 : 처음 API를 작성할 때, Review Entity 자체를 response하여 순환 참조가 발생했음. @JsonIgnore을 이용해서 해결할까 했지만, ResponseDTO를 이용하여 필요한 데이터만 담아서 client에 response했음.

- #9 #10 : 앞서 작성했던 User의 update, delete API와 동일한 기능이어서 수월하게 작성할 수 있었음. 앞으로 사용자를 인증하는 기능이 필요하다고 생각함.

- #11 : User Entity로 조건을 걸어 Review를 조회하는 방식을 사용.